### PR TITLE
Change active mapping from title to url

### DIFF
--- a/sidebar/components/sidebar.py
+++ b/sidebar/components/sidebar.py
@@ -69,7 +69,7 @@ def sidebar_item(text: str, url: str) -> rx.Component:
         rx.Component: The sidebar item component.
     """
     # Whether the item is active.
-    active = (rx.State.router.page.path == f"/{text.lower()}") | (
+    active = (rx.State.router.page.path == url.lower()) | (
         (rx.State.router.page.path == "/") & text == "Home"
     )
 


### PR DESCRIPTION
The sidebar currently maps the active state using the path and title. 

I propose switching this to use the URL instead, as it provides a more accurate mapping.